### PR TITLE
Removed Shouldly using statement from template

### DIFF
--- a/tools/Legerity.Uno.PageObjectGenerator/Program.cs
+++ b/tools/Legerity.Uno.PageObjectGenerator/Program.cs
@@ -8,10 +8,10 @@ using Serilog;
 
 public class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
         SerilogConfigurator.ConfigureLogging();
-        Parser.Default.ParseArguments<Options>(args)
+        await Parser.Default.ParseArguments<Options>(args)
             .WithNotParsed(errors =>
             {
                 foreach (Error? error in errors)
@@ -30,8 +30,11 @@ public class Program
                 {
                     Directory.CreateDirectory(options.OutputPath);
                 }
-                
-                await new XamlPageObjectGenerator().GenerateAsync(options.Namespace, options.InputPath, options.OutputPath);
+
+                await new XamlPageObjectGenerator().GenerateAsync(
+                    options.Namespace,
+                    options.InputPath,
+                    options.OutputPath);
 
                 Log.Information("Finished generating Legerity for Uno Platform page objects!");
             });

--- a/tools/Legerity.Uno.PageObjectGenerator/Templates/UnoPageObject.template
+++ b/tools/Legerity.Uno.PageObjectGenerator/Templates/UnoPageObject.template
@@ -9,7 +9,6 @@ using Legerity.Uno.Extensions;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Remote;
-using Shouldly;
 using ByExtensions = Legerity.Windows.Extensions.ByExtensions;
 
 namespace {{namespace}}


### PR DESCRIPTION
## Resolves #132 
<!-- Add the issue ID after the '#' to automatically close the issue once the PR is merged -->

<!-- Please provide a description below of the changes made and how it has been tested -->

Fixed issue with Shouldly appearing in the generated page objects.

## PR checklist

- [ ] Have Uno Platform samples and Legerity tests been added or updated, run locally, and all pass
- [ ] Have added or updated support for Uno Platform element wrappers been reflected in the Page Object Generator
- [x] Have code styling rules been run on all new source file changes
- [ ] Have relevant articles in the docs been added or updated for all new source file changes
- [ ] Have major breaking changes been made and are documented

<!-- If a breaking change has been made, please provide a detailed description below of the impact and the migration path -->

## Other information
<!-- Provide any additional information below that may be relevant to the changes made (e.g. app screenshots, documentation links, or existing PR reference) -->